### PR TITLE
Correção da importação do MenuIcon no componente Header

### DIFF
--- a/webapp/src/components/Header.jsx
+++ b/webapp/src/components/Header.jsx
@@ -7,10 +7,10 @@ import {
   Container,
   IconButton,
   Menu,
-  MenuIcon,
   MenuItem,
   Toolbar,
 } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
 import { Link as RouterLink } from "react-router-dom";
 
 // lista as páginas e referências a serem exibidas no menu


### PR DESCRIPTION
A importação do componente de ícone "MenuIcon" estava incorreta, fazendo com o que a aplicação não inicializasse. Este problema também estava ocasionando o erro na pipeline, provavalmente sendo o motivo que etava impedinto o build e deploy da aplicação.